### PR TITLE
Fix NPE when using jar files with no manifest, Fixes #24

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/io/FixedJarInputStream.java
+++ b/src/main/java/com/github/parker8283/bon2/io/FixedJarInputStream.java
@@ -19,7 +19,9 @@ public class FixedJarInputStream extends JarInputStream {
         super(new FileInputStream(file), verify);
         JarFile jar = new JarFile(file);
         JarEntry manifestEntry = jar.getJarEntry(JarFile.MANIFEST_NAME);
-        this.manifest = new Manifest(jar.getInputStream(manifestEntry));
+        if(manifestEntry != null){
+            this.manifest = new Manifest(jar.getInputStream(manifestEntry));
+        }
     }
 
     @Override

--- a/src/main/java/com/github/parker8283/bon2/util/JarUtils.java
+++ b/src/main/java/com/github/parker8283/bon2/util/JarUtils.java
@@ -76,7 +76,9 @@ public class JarUtils {
             jout = new JarOutputStream(new FileOutputStream(file));
             addDirectories(JarFile.MANIFEST_NAME, dirs);
             jout.putNextEntry(new JarEntry(JarFile.MANIFEST_NAME));
-            cc.getManifest().write(jout);
+            if(cc.getManifest() != null){
+                cc.getManifest().write(jout);
+            }
             jout.closeEntry();
             progress.setProgress(++classesWritten);
             for(ClassNode classNode : cc.getClasses()) {
@@ -116,6 +118,9 @@ public class JarUtils {
     }
 
     private static Manifest stripManifest(Manifest manifestIn) {
+        if(manifestIn == null){
+            return manifestIn;
+        }
         Manifest manifestOut = new Manifest(manifestIn);
         for(Map.Entry<String, Attributes> entry : manifestIn.getEntries().entrySet()) {
             manifestOut.getEntries().remove(entry.getKey());


### PR DESCRIPTION
This is a small PR that fixes a crash from happening when the input jar doesnt have a manifest file. 

Feel free to close it if you like.
