### PR TITLE
Fixed gradle home custom + Jar not having a manifest

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/data/BONFiles.java
+++ b/src/main/java/com/github/parker8283/bon2/data/BONFiles.java
@@ -4,16 +4,28 @@ import java.io.File;
 
 public class BONFiles {
     public static File USER_GRADLE_FOLDER = new File(System.getProperty("user.home") + File.separator + ".gradle");
-    public static final File GRADLE_CACHES_FOLDER = new File(USER_GRADLE_FOLDER, "caches");
-    public static final File CACHES_MINECRAFT_FOLDER = new File(GRADLE_CACHES_FOLDER, "minecraft");
-    public static final File MINECRAFT_NET_FOLDER = new File(CACHES_MINECRAFT_FOLDER, "net");
-    public static final File NET_MINECRAFTFORGE_FOLDER = new File(MINECRAFT_NET_FOLDER, "minecraftforge");
-    public static final File MINECRAFTFORGE_FORGE_FOLDER = new File(NET_MINECRAFTFORGE_FOLDER, "forge");
-    public static final File MINECRAFT_DE_FOLDER = new File(CACHES_MINECRAFT_FOLDER, "de");
-    public static final File DE_OCEANLABS_FOLDER = new File(MINECRAFT_DE_FOLDER, "oceanlabs");
-    public static final File OCEANLABS_MCP_FOLDER = new File(DE_OCEANLABS_FOLDER, "mcp");
+    public static File GRADLE_CACHES_FOLDER;
+    public static File CACHES_MINECRAFT_FOLDER;
+    public static File MINECRAFT_NET_FOLDER;
+    public static File NET_MINECRAFTFORGE_FOLDER;
+    public static File MINECRAFTFORGE_FORGE_FOLDER;
+    public static File MINECRAFT_DE_FOLDER;
+    public static File DE_OCEANLABS_FOLDER;
+    public static File OCEANLABS_MCP_FOLDER;
+    
+    public static void load() {
+    	GRADLE_CACHES_FOLDER = new File(USER_GRADLE_FOLDER, "caches");
+    	CACHES_MINECRAFT_FOLDER = new File(GRADLE_CACHES_FOLDER, "minecraft");
+    	MINECRAFT_NET_FOLDER = new File(CACHES_MINECRAFT_FOLDER, "net");
+    	NET_MINECRAFTFORGE_FOLDER = new File(MINECRAFT_NET_FOLDER, "minecraftforge");
+    	MINECRAFTFORGE_FORGE_FOLDER = new File(NET_MINECRAFTFORGE_FOLDER, "forge");
+    	MINECRAFT_DE_FOLDER = new File(CACHES_MINECRAFT_FOLDER, "de");
+    	DE_OCEANLABS_FOLDER = new File(MINECRAFT_DE_FOLDER, "oceanlabs");
+    	OCEANLABS_MCP_FOLDER = new File(DE_OCEANLABS_FOLDER, "mcp");
+    }
 
     public static void setUserHome(File userGradle) {
         USER_GRADLE_FOLDER = userGradle;
+        load();
     }
 }

--- a/src/main/java/com/github/parker8283/bon2/io/FixedJarInputStream.java
+++ b/src/main/java/com/github/parker8283/bon2/io/FixedJarInputStream.java
@@ -19,7 +19,9 @@ public class FixedJarInputStream extends JarInputStream {
         super(new FileInputStream(file), verify);
         JarFile jar = new JarFile(file);
         JarEntry manifestEntry = jar.getJarEntry(JarFile.MANIFEST_NAME);
-        this.manifest = new Manifest(jar.getInputStream(manifestEntry));
+        if (manifestEntry != null) {
+            this.manifest = new Manifest(jar.getInputStream(manifestEntry));
+        }
     }
 
     @Override

--- a/src/main/java/com/github/parker8283/bon2/util/JarUtils.java
+++ b/src/main/java/com/github/parker8283/bon2/util/JarUtils.java
@@ -54,7 +54,9 @@ public class JarUtils {
                 }
                 progress.setProgress((int)(currentProgress += entry.getCompressedSize()));
             }
-            manifest = stripManifest(jin.getManifest());
+            if (jin.getManifest() != null) {
+                manifest = stripManifest(jin.getManifest());
+            }
             progress.setProgress((int)fileSize);
         } finally {
             if(jin != null) {
@@ -76,7 +78,9 @@ public class JarUtils {
             jout = new JarOutputStream(new FileOutputStream(file));
             addDirectories(JarFile.MANIFEST_NAME, dirs);
             jout.putNextEntry(new JarEntry(JarFile.MANIFEST_NAME));
-            cc.getManifest().write(jout);
+            if (cc.getManifest() != null) {
+                cc.getManifest().write(jout);
+            }
             jout.closeEntry();
             progress.setProgress(++classesWritten);
             for(ClassNode classNode : cc.getClasses()) {


### PR DESCRIPTION
Now if you have a gradle home custom, it will load the versions correctly and jar without manifests can now be deobfuscated.
