### PR TITLE
Fix unchecked warnings in RefreshListener

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/BON2Gui.java
+++ b/src/main/java/com/github/parker8283/bon2/BON2Gui.java
@@ -62,7 +62,7 @@ public class BON2Gui extends JFrame {
 
         lblForgeVer = new JLabel("Forge Version");
 
-        JComboBox forgeVersions = new JComboBox();
+        JComboBox<String> forgeVersions = new JComboBox<String>();
 
         JButton btnRefreshVers = new JButton("Refresh");
         RefreshListener refresh = new RefreshListener(this, forgeVersions);

--- a/src/main/java/com/github/parker8283/bon2/gui/RefreshListener.java
+++ b/src/main/java/com/github/parker8283/bon2/gui/RefreshListener.java
@@ -13,9 +13,9 @@ import com.github.parker8283.bon2.util.BONUtils;
 
 public class RefreshListener extends MouseAdapter {
     private Component parent;
-    private JComboBox comboBox;
+    private JComboBox<String> comboBox;
 
-    public RefreshListener(Component parent, JComboBox comboBox) {
+    public RefreshListener(Component parent, JComboBox<String> comboBox) {
         this.parent = parent;
         this.comboBox = comboBox;
     }
@@ -30,7 +30,6 @@ public class RefreshListener extends MouseAdapter {
 
         comboBox.removeAllItems();
         for(String version : BONUtils.buildValidMappings()) {
-            //noinspection unchecked
             comboBox.addItem(version);
         }
     }


### PR DESCRIPTION
This removes a `noinspection` and cleans up the build log a little bit. It doesn't need to be unchecked because we know that `BONUtils#buildValidMappings` always returns a `List<String>`, and those values are the only thing ever added to this `JComboBox`.