### PR TITLE
Fix VersionLookup not being populated outside of the GUI

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/BON2.java
+++ b/src/main/java/com/github/parker8283/bon2/BON2.java
@@ -13,6 +13,7 @@ import com.github.parker8283.bon2.cli.CLIProgressListener;
 import com.github.parker8283.bon2.data.BONFiles;
 import com.github.parker8283.bon2.data.IErrorHandler;
 import com.github.parker8283.bon2.data.MappingVersion;
+import com.github.parker8283.bon2.data.VersionLookup;
 import com.github.parker8283.bon2.exception.InvalidMappingsVersionException;
 import com.github.parker8283.bon2.util.BONUtils;
 
@@ -63,6 +64,8 @@ public class BON2 {
                 new FileNotFoundException(inputJar).printStackTrace();
                 System.exit(1);
             }
+            
+            VersionLookup.INSTANCE.refresh();
             
             List<MappingVersion> mappings = BONUtils.buildValidMappings();
             MappingVersion mapping = null;


### PR DESCRIPTION
`VersionLookup#refresh` was only being called in the `BON2Gui` constructor, so it was always empty when used by the command-line.

This was causing the following exception to be thrown when populating the mappings versions:
```
Exception in thread "main" java.lang.NumberFormatException: For input string: "banana"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.valueOf(Integer.java:766)
	at com.github.parker8283.bon2.data.MappingVersion.compareTo(MappingVersion.java:67)
	at com.github.parker8283.bon2.data.MappingVersion.compareTo(MappingVersion.java:7)
	at java.util.ComparableTimSort.countRunAndMakeAscending(ComparableTimSort.java:325)
	at java.util.ComparableTimSort.sort(ComparableTimSort.java:188)
	at java.util.Arrays.sort(Arrays.java:1312)
	at java.util.Arrays.sort(Arrays.java:1506)
	at java.util.ArrayList.sort(ArrayList.java:1454)
	at com.github.parker8283.bon2.util.BONUtils.buildValidMappings(BONUtils.java:80)
	at com.github.parker8283.bon2.BON2.parseArgs(BON2.java:70)
	at com.github.parker8283.bon2.BON2.main(BON2.java:29)
```

This PR adds a call to `VersionLookup#refresh` just before the mappings versions are populated.