### PR TITLE
Added safety for removable drives.

### DIFF
--- a/src/main/java/com/github/parker8283/bon2/gui/BrowseListener.java
+++ b/src/main/java/com/github/parker8283/bon2/gui/BrowseListener.java
@@ -40,6 +40,9 @@ public class BrowseListener extends MouseAdapter {
         String key = isOpen ? BON2Gui.PREFS_KEY_OPEN_LOC : BON2Gui.PREFS_KEY_SAVE_LOC;
         String savedDir = parent.prefs.get(key, Paths.get("").toAbsolutePath().toString());
         File currentDir = new File(savedDir);
+        if(!Paths.get(savedDir).getRoot().toFile().exists()){
+            currentDir = Paths.get("").toAbsolutePath().toFile();
+        }
         while (!currentDir.isDirectory()) {
             currentDir = currentDir.getParentFile();
         }


### PR DESCRIPTION
Added a check that will reset currentDir to the working directory if the saved openLoc was on a removable drive that has been removed.

This prevents a NullPointerException when the while loop attempts to walk up the hierarchy.